### PR TITLE
enable commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional']
+};

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
+    "@commitlint/cli": "^7.3.2",
+    "@commitlint/config-conventional": "^7.3.1",
     "babel-loader": "^8.0.4",
     "babel-plugin-import": "^1.9.1",
     "css-loader": "^0.28.11",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "babel-loader": "^8.0.4",
     "babel-plugin-import": "^1.9.1",
     "css-loader": "^0.28.11",
+    "husky": "^1.3.1",
     "node-sass": "^4.9.3",
     "nodemon": "^1.18.7",
     "prettier": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -76,5 +76,10 @@
       "src/public/**/*.*"
     ],
     "delay": "2500"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
   }
 }


### PR DESCRIPTION
hey Bogdan,

as I told you before, I really believe this project is going big. So we probably need to set some rules for code quality.

this PR enables commitlint, a tool that enforces a clear naming convention for commits. I also linked it with husky to run automatically.

what do you think ?