### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Check out the example of [**standalone version running here**](https://codecrumb
 ### Install and run
 >Pre-condition: update/install `NodeJS` version to be >= *8.11.1*  
  
-1) Install ```codecrumbs``` globally (```yarn gloabl add codecrumbs```)
+1) Install ```codecrumbs``` globally (```yarn global add codecrumbs```).
 2) Run ```codecrumbs -d project-src-dir -e project-src-dir/index.js```. Change parameters to match your project:```-d``` is *directory with source code*, ```-e``` is *entry point file* .
 3) Go to [http://localhost:2018](http://localhost:2018/#) in the browser to check it out.
 
@@ -58,7 +58,8 @@ UI explained:
 3) Codecrumb details
 4) Folder is in "active only" state, you can expand to show all children
 
-**How to get there?** Leave breadcrumb in code by writing down a comment: ```//cc:[parameters;]```.
+#### How to get there?
+Leave breadcrumb in code by writing down a comment: ```//cc:[parameters;]```.
 
 ```cc``` (stands for "CodeCrumb") is a prefix which used by the parser; check example of parameters in the table below:  
  


### PR DESCRIPTION
- Fix typo in README: `yarn global add codecrumbs`.
- Change **How to get there?** to H4 to enable anchor link: `#how-to-get-there`.