### PR TITLE
feat: add support for madge to resolve tsConfig path aliases 

### DIFF
--- a/cli/index.cli.js
+++ b/cli/index.cli.js
@@ -16,6 +16,10 @@ program
     '-w, --webpack [webpackConfigFile]',
     'Specify path to webpack config file. E.g. webpack.config.js'
   )
+  .option(
+    '-w, --ts [tsConfigFile]',
+    'Specify path to typeScript config file. E.g. tsConfig.json'
+  )
   .option('-p, --port [defaultPort]', 'Specify port for Codecrumbs client. E.g. 3333', 2018)
   .option('-x, --excludeDir [excludeDirectories]', 'Exclude directories')
   .option('-n, --projectName [projectNameAlias]', 'Project name alias')
@@ -36,6 +40,7 @@ server.setup(
     entryPoint: program.entry,
     projectDir: program.dir,
     webpackConfigPath: program.webpack,
+    tsConfigPath: program.ts,
     clientPort: program.port,
     excludeDir: program.excludeDir
   },

--- a/cli/index.cli.js
+++ b/cli/index.cli.js
@@ -17,7 +17,7 @@ program
     'Specify path to webpack config file. E.g. webpack.config.js'
   )
   .option(
-    '-w, --ts [tsConfigFile]',
+    '-ts, --tsConfig [tsConfigFile]',
     'Specify path to typeScript config file. E.g. tsConfig.json'
   )
   .option('-p, --port [defaultPort]', 'Specify port for Codecrumbs client. E.g. 3333', 2018)

--- a/example-project/src-typescript/components/login/loginPage.tsx
+++ b/example-project/src-typescript/components/login/loginPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Card, CardHeader, CardContent } from '@material-ui/core';
-import { LoginForm } from './loginForm';
+import { LoginForm } from '@src/components/login/loginForm';
 import { isValidLogin } from '../../api/login';
 import { LoginEntity, createEmptyLogin } from '../../model';
 import { NotificationComponent } from '../../common/components/notification';

--- a/example-project/src-typescript/tsConfig.json
+++ b/example-project/src-typescript/tsConfig.json
@@ -1,0 +1,9 @@
+{ 
+  "compilerOptions": {
+  "baseUrl": "example-project",
+  "moduleResolution": "node",
+   "paths": {
+    "@src/*": ["src-typescript/*"]
+  }
+  }
+}

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -19,6 +19,7 @@ const namespaceTypeScriptExample = {
     projectNameAlias: 'ts-example-server',
     projectDir: `example-project/src-typescript`,
     entryPoint: `example-project/src-typescript/index.tsx`,
+    tsConfigPath: `example-project/src-typescript/tsConfig.json`,
     clientPort: 2018
   };
 

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -3,13 +3,15 @@ const exec = require('child_process').exec;
 const logger = require('../utils/logger');
 const codeParser = require('../code-parse');
 
-const parseFiles = ({ path, parseDependencies }, projectDir, language) =>
+const parseFiles = ({ path, parseDependencies,  webpackConfigPath, tsConfigPath }, projectDir, language) => 
   Promise.all(
     path.map(itemPath =>
       codeParser.parseFile(itemPath, projectDir, {
         attachCode: true,
         parseDependencies,
-        language
+        language,
+        webpackConfigPath,
+        tsConfigPath
       })
     )
   );

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -3,7 +3,7 @@ const exec = require('child_process').exec;
 const logger = require('../utils/logger');
 const codeParser = require('../code-parse');
 
-const parseFiles = ({ path, parseDependencies,  webpackConfigPath, tsConfigPath }, projectDir, language) => 
+const parseFiles = ( {path, parseDependencies}, {webpackConfigPath, tsConfigPath , projectDir, language}) => 
   Promise.all(
     path.map(itemPath =>
       codeParser.parseFile(itemPath, projectDir, {

--- a/src/server/code-parse/index.js
+++ b/src/server/code-parse/index.js
@@ -4,12 +4,12 @@ const { getLanguageParsers } = require('./language');
 const parseFile = (
   itemPath,
   projectDir,
-  { parseCodeCrumbs, parseImports, parseDependencies, attachCode, language } = {}
+  { parseCodeCrumbs, parseImports, parseDependencies, attachCode, language, webpackConfigPath, tsConfigPath } = {}
 ) => {
   const { codecrumbsParser, dependenciesParser } = getLanguageParsers(language);
-
+  
   return Promise.all([
-    parseDependencies && dependenciesParser.getDependencies(itemPath, projectDir),
+    parseDependencies && dependenciesParser.getDependencies(itemPath, projectDir, {webpackConfigPath, tsConfigPath}),
     file.read(itemPath, 'utf8')
   ]).then(([dependencies, code]) => {
     const item = {

--- a/src/server/code-parse/language/default/dependencies.js
+++ b/src/server/code-parse/language/default/dependencies.js
@@ -4,7 +4,7 @@ const getImports = (fileCode, itemPath) => {
   return importedDependencies;
 };
 
-const getDependencies = (entryPoint, projectDir, webpackConfigPath) => {
+const getDependencies = (entryPoint, projectDir,{}) => {
   return Promise.resolve([]);
 };
 

--- a/src/server/code-parse/language/javascript/dependencies.js
+++ b/src/server/code-parse/language/javascript/dependencies.js
@@ -4,7 +4,7 @@ const madge = require('madge');
 const jsDependencies = require('../../../utils/jsDependencies');
 const { config: astParseConfig, getNodeLines } = require('./astParse');
 
-const getDependencies = (entryPoint, projectDir, webpackConfigPath) => {
+const getDependencies = (entryPoint, projectDir, {webpackConfigPath}) => {
   const rootPath = path.resolve();
   const separator = path.sep;
 

--- a/src/server/code-parse/language/typescript/dependencies.js
+++ b/src/server/code-parse/language/typescript/dependencies.js
@@ -4,7 +4,7 @@ const madge = require('madge');
 const jsDependencies = require('../../../utils/jsDependencies');
 const { config: astParseConfig, getNodeLines } = require('./astParse');
 
-const getDependencies = (entryPoint, projectDir, webpackConfigPath, tsConfig = {}) => {
+const getDependencies = (entryPoint, projectDir, { webpackConfigPath, tsConfigPath}) => {
   // TODO: investigated usage for tsConfig param
   const rootPath = path.resolve();
   const separator = path.sep;
@@ -12,6 +12,7 @@ const getDependencies = (entryPoint, projectDir, webpackConfigPath, tsConfig = {
   return madge(entryPoint, {
     webpackConfig: webpackConfigPath,
     baseDir: projectDir,
+    tsConfig: tsConfigPath,
     // TODO: this filter will be extended based on how much dependencies is needed
     dependencyFilter: (depPath, sourcePath) => sourcePath === `${rootPath}${separator}${entryPoint}`
   })

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -18,6 +18,7 @@ const setup = (options, isDev) => {
     projectDir,
     entryPoint,
     webpackConfigPath,
+    tsConfigPath,
     clientPort,
     excludeDir
   } = options;
@@ -72,6 +73,7 @@ const setup = (options, isDev) => {
           projectDir: alignPlatformPath(projectDir),
           entryPoint: alignPlatformPath(entryPoint),
           webpackConfigPath: alignPlatformPath(webpackConfigPath),
+          tsConfigPath: alignPlatformPath(tsConfigPath),
           excludeDir: (excludeDir ? excludeDir.split(',') : []).map(alignPlatformPath)
         }
       );

--- a/src/server/project-source/index.js
+++ b/src/server/project-source/index.js
@@ -17,6 +17,7 @@ const parseProjectSourceFiles = ({
   projectDir,
   entryPoint,
   webpackConfigPath,
+  tsConfigPath,
   language
 }) =>
   Promise.all(
@@ -27,6 +28,8 @@ const parseProjectSourceFiles = ({
           parseImports: true,
           parseDependencies: itemPath === entryPoint,
           attachCode: itemPath === entryPoint,
+          webpackConfigPath,
+          tsConfigPath,
           language
         })
         .then(item =>
@@ -49,7 +52,7 @@ const closePreviousSubscription = id => {
 
 const subscribeOnChange = (
   namespace,
-  { projectName, projectDir, entryPoint, excludeDir, webpackConfigPath, language, fileExtensions },
+  { projectName, projectDir, entryPoint, excludeDir, webpackConfigPath,tsConfigPath, language, fileExtensions },
   { onInit, onChange }
 ) => {
   logger.info(`> source watcher subscribing for changes`);
@@ -78,6 +81,7 @@ const subscribeOnChange = (
     projectDir,
     entryPoint,
     webpackConfigPath,
+    tsConfigPath,
     language
   })
     .then(() => {

--- a/src/server/source-watcher.js
+++ b/src/server/source-watcher.js
@@ -10,7 +10,7 @@ const { detectLanguage } = require('./code-parse/language');
 
 const run = (
   { mediatorEndPoint, namespace, projectName },
-  { projectDir, entryPoint, webpackConfigPath, excludeDir }
+  { projectDir, entryPoint, webpackConfigPath, tsConfigPath, excludeDir }
 ) => {
   const { language, extensions: fileExtensions } = detectLanguage(entryPoint);
 
@@ -26,7 +26,9 @@ const run = (
   webSocketClient.on('connect', connection => {
     logger.info(
       `+ started: source watcher: ${namespace} for: ${projectName}; `,
-      `setup: dir - ${projectDir}, entry point - ${entryPoint}`
+      `setup: dir - ${projectDir}, entry point - ${entryPoint}`,
+      `options: webPackConfig - ${webpackConfigPath}, tsConfig - ${tsConfigPath}`
+
     );
 
     connection.on('message', ({ utf8Data }) => {
@@ -42,6 +44,7 @@ const run = (
               entryPoint,
               excludeDir,
               webpackConfigPath,
+              tsConfigPath,
               language,
               fileExtensions
             },
@@ -70,7 +73,7 @@ const run = (
 
         case SOCKET_MESSAGE_TYPE.CLIENT_REQUEST_FETCH_FILE:
           if (message.namespace === namespace) {
-            parseFiles(message.data, projectDir, language).then(files =>
+            parseFiles({...message.data, webpackConfigPath, tsConfigPath }, projectDir, language).then(files =>
               connection.sendUTF(
                 JSON.stringify({
                   type: SOCKET_MESSAGE_TYPE.SOURCE_RESPONSE_FETCH_FILE,

--- a/src/server/source-watcher.js
+++ b/src/server/source-watcher.js
@@ -73,7 +73,7 @@ const run = (
 
         case SOCKET_MESSAGE_TYPE.CLIENT_REQUEST_FETCH_FILE:
           if (message.namespace === namespace) {
-            parseFiles({...message.data, webpackConfigPath, tsConfigPath }, projectDir, language).then(files =>
+            parseFiles( message.data, {webpackConfigPath, tsConfigPath , projectDir, language}).then(files =>
               connection.sendUTF(
                 JSON.stringify({
                   type: SOCKET_MESSAGE_TYPE.SOURCE_RESPONSE_FETCH_FILE,


### PR DESCRIPTION
- [x] add a cli flag to pass an optional `tsConfig` file 

- [x] get the `tsConfig` file path passed as an argument to madge in `typescript` `getDependencies` function