### PR TITLE
chore: import only getCrumbs

### DIFF
--- a/src/server/code-parse/language/cpp/codecrumbs.js
+++ b/src/server/code-parse/language/cpp/codecrumbs.js
@@ -1,7 +1,4 @@
-const { setupGetCrumbs, setupGetCommentsFromCode } = require('../default/codecrumbs');
-
-const CPP_COMMENT_REGEX = /^([^\/\/]*)\/\/(.*)$/;
-const getCrumbs = setupGetCrumbs(setupGetCommentsFromCode(CPP_COMMENT_REGEX));
+const { getCrumbs } = require('../default/codecrumbs');
 
 // replace with own implementation if needed
 module.exports = {

--- a/src/server/code-parse/language/csharp/codecrumbs.js
+++ b/src/server/code-parse/language/csharp/codecrumbs.js
@@ -1,8 +1,4 @@
-const { setupGetCrumbs, setupGetCommentsFromCode } = require('../default/codecrumbs');
-
-const CSHARP_COMMENT_REGEX = /^([^\/\/]*)\/\/(.*)$/;
-const getCrumbs = setupGetCrumbs(setupGetCommentsFromCode(CSHARP_COMMENT_REGEX));
-
+const { getCrumbs } = require('../default/codecrumbs');
 // replace with own implementation if needed
 module.exports = {
   getCrumbs

--- a/src/server/code-parse/language/golang/codecrumbs.js
+++ b/src/server/code-parse/language/golang/codecrumbs.js
@@ -1,7 +1,4 @@
-const { setupGetCrumbs, setupGetCommentsFromCode } = require('../default/codecrumbs');
-
-const GOLANG_COMMENT_REGEX = /^([^\/\/]*)\/\/(.*)$/
-const getCrumbs = setupGetCrumbs(setupGetCommentsFromCode(GOLANG_COMMENT_REGEX));
+const { getCrumbs } = require('../default/codecrumbs');
 
 // replace with own implementation if needed
 module.exports = {

--- a/src/server/code-parse/language/java/codecrumbs.js
+++ b/src/server/code-parse/language/java/codecrumbs.js
@@ -1,7 +1,4 @@
-const { setupGetCrumbs, setupGetCommentsFromCode } = require('../default/codecrumbs');
-
-const JAVA_COMMENT_REGEX = /^([^\/\/]*)\/\/(.*)$/;
-const getCrumbs = setupGetCrumbs(setupGetCommentsFromCode(JAVA_COMMENT_REGEX));
+const { getCrumbs } = require('../default/codecrumbs');
 
 // replace with own implementation if needed
 module.exports = {

--- a/src/server/code-parse/language/javascript/codecrumbs.js
+++ b/src/server/code-parse/language/javascript/codecrumbs.js
@@ -23,11 +23,9 @@ const getCrumbs = (fileCode, path) => {
   }
 };*/
 
-const { setupGetCrumbs, setupGetCommentsFromCode } = require('../default/codecrumbs');
+const { getCrumbs } = require('../default/codecrumbs');
 
-const JAVA_SCRIPT_COMMENT_REGEX = /^([^\/\/]*)\/\/(.*)$/;
-const getCrumbs = setupGetCrumbs(setupGetCommentsFromCode(JAVA_SCRIPT_COMMENT_REGEX));
-
+// replace with own implementation if needed
 module.exports = {
   getCrumbs
 };

--- a/src/server/code-parse/language/kotlin/codecrumbs.js
+++ b/src/server/code-parse/language/kotlin/codecrumbs.js
@@ -1,7 +1,4 @@
-const { setupGetCrumbs, setupGetCommentsFromCode } = require('../default/codecrumbs');
-
-const KOTLIN_COMMENT_REGEX = /^([^\/\/]*)\/\/(.*)$/;
-const getCrumbs = setupGetCrumbs(setupGetCommentsFromCode(KOTLIN_COMMENT_REGEX));
+const { getCrumbs } = require('../default/codecrumbs');
 
 // replace with own implementation if needed
 module.exports = {

--- a/src/server/code-parse/language/php/codecrumbs.js
+++ b/src/server/code-parse/language/php/codecrumbs.js
@@ -1,7 +1,4 @@
-const { setupGetCrumbs, setupGetCommentsFromCode } = require('../default/codecrumbs');
-
-const PHP_COMMENT_REGEX = /^([^\/\/]*)\/\/(.*)$/;
-const getCrumbs = setupGetCrumbs(setupGetCommentsFromCode(PHP_COMMENT_REGEX));
+const { getCrumbs } = require('../default/codecrumbs');
 
 // replace with own implementation if needed
 module.exports = {

--- a/src/server/code-parse/language/typescript/codecrumbs.js
+++ b/src/server/code-parse/language/typescript/codecrumbs.js
@@ -1,7 +1,4 @@
-const { setupGetCrumbs, setupGetCommentsFromCode } = require('../default/codecrumbs');
-
-const TYPE_SCRIPT_COMMENT_REGEX = /^([^\/\/]*)\/\/(.*)$/;
-const getCrumbs = setupGetCrumbs(setupGetCommentsFromCode(TYPE_SCRIPT_COMMENT_REGEX));
+const { getCrumbs } = require('../default/codecrumbs');
 
 // replace with own implementation if needed
 module.exports = {


### PR DESCRIPTION
as I got, we could reuse existing `getCrumbs` as the default, since we already have it