### PR TITLE
Add support for Rust

### DIFF
--- a/src/server/code-parse/language/index.js
+++ b/src/server/code-parse/language/index.js
@@ -17,6 +17,7 @@ const LANGUAGES = [
   'php',
   'python',
   'ruby',
+  'rust',
   'typescript'
 ];
 

--- a/src/server/code-parse/language/rust/codecrumbs.js
+++ b/src/server/code-parse/language/rust/codecrumbs.js
@@ -1,0 +1,6 @@
+const { getCrumbs } = require('../default/codecrumbs');
+
+// replace with own implementation if needed
+module.exports = {
+  getCrumbs
+};

--- a/src/server/code-parse/language/rust/dependencies.js
+++ b/src/server/code-parse/language/rust/dependencies.js
@@ -1,0 +1,7 @@
+const defaultDependencies = require('../default/dependencies');
+
+// replace with own implementation if needed
+module.exports = {
+  getImports: defaultDependencies.getImports,
+  getDependencies: defaultDependencies.getDependencies
+};

--- a/src/server/code-parse/language/rust/extensions.js
+++ b/src/server/code-parse/language/rust/extensions.js
@@ -1,0 +1,1 @@
+module.exports = /\.rs$/;


### PR DESCRIPTION
This adds support for Rust by copying the config for C++.

The comments in Rust start with `//`. There are also doc comments `///`
and `//!`, as well as multiline comments `/* ... */`, but they are not
considered here.